### PR TITLE
env: import.meta -> process

### DIFF
--- a/src/server/env.ts
+++ b/src/server/env.ts
@@ -12,4 +12,4 @@ if (typeof window !== "undefined") {
   throw new Error("server env is on client!!");
 }
 
-export const env = envScheme.parse(import.meta.env);
+export const env = envScheme.parse(process.env);


### PR DESCRIPTION
I don't know if it's right, but I seem to need this, otherwise, my env vars are not used.

I mean, like with `docker run -e`. In prod.

They do seem to recommend `import.meta` though https://github.com/BuilderIO/qwik/issues/1147 .